### PR TITLE
Don't mangle inputs array when making embeddings calls

### DIFF
--- a/lib/src/embeddings.dart
+++ b/lib/src/embeddings.dart
@@ -39,7 +39,7 @@ class OpenAIEmbeddings {
 
     final jsonBody = <String, dynamic>{
       'model': model,
-      'input': input.map((e) => '$e\n').toString(),
+      'input': input,
       if (user != null) 'user': user,
     };
 


### PR DESCRIPTION
Currently, the embeddings api code aggregates the list of inputs into a single escaped string, which prevents users of this library from sending batch embeddings requests. This patch changes the behaviour of the method to make it match the API documentation.