### PR TITLE
Update model.dart

### DIFF
--- a/lib/src/model/model.dart
+++ b/lib/src/model/model.dart
@@ -4,3 +4,4 @@ export 'openai_embeddings/openai_embeddings.dart';
 export 'openai_images/openai_images.dart';
 export 'openai_models/openai_models.dart';
 export 'openai_moderation/openai_moderation.dart';
+export 'openai_chat/chat_message.dart';


### PR DESCRIPTION
One export was missing which is causing the usage of `chat_message `